### PR TITLE
Update the apply_peribolos to create the teams

### DIFF
--- a/.github/workflows/apply_peribolos.yml
+++ b/.github/workflows/apply_peribolos.yml
@@ -49,6 +49,6 @@ jobs:
           /tmp/ghproxy --legacy-disable-disk-cache-partitions-by-auth-header=false --get-throttling-time-ms=300 --throttling-time-ms=900 --throttling-time-v4-ms=850 --throttling-max-delay-duration-seconds=45 --throttling-max-delay-duration-v4-seconds=110 --request-timeout=120 1>/dev/null 2>&1 &
           pid=$!
           jobs
-          /tmp/peribolos -config-path /tmp/peribolos.yaml  --fix-org --fix-org-members --fix-repos -min-admins 2 --github-token-path auth.txt --confirm 2>&1 | jq -r '[.severity, .time, .msg] | join(" | ")'
+          /tmp/peribolos -config-path /tmp/peribolos.yaml  --fix-org --fix-org-members --fix-teams --fix-team-members --fix-repos -min-admins 2 --github-token-path auth.txt --confirm 2>&1 | jq -r '[.severity, .time, .msg] | join(" | ")'
           kill $pid
           rm auth.txt


### PR DESCRIPTION
The teams' information is the new addition that needs the teams' fields to support.
If the Peribolos CLI does not have the "`--fix-teams --fix-team-members`", the
workflow will skip the creating `teams` step.

The reference is [here](https://docs.prow.k8s.io/docs/components/cli-tools/peribolos/).