### PR TITLE
fix(ci): adds fix-team-repos flag to peribolos apply step

### DIFF
--- a/.github/workflows/apply_peribolos.yml
+++ b/.github/workflows/apply_peribolos.yml
@@ -49,6 +49,6 @@ jobs:
           /tmp/ghproxy --legacy-disable-disk-cache-partitions-by-auth-header=false --get-throttling-time-ms=300 --throttling-time-ms=900 --throttling-time-v4-ms=850 --throttling-max-delay-duration-seconds=45 --throttling-max-delay-duration-v4-seconds=110 --request-timeout=120 1>/dev/null 2>&1 &
           pid=$!
           jobs
-          /tmp/peribolos -config-path /tmp/peribolos.yaml  --fix-org --fix-org-members --fix-teams --fix-team-members --fix-repos -min-admins 2 --github-token-path auth.txt --confirm 2>&1 | jq -r '[.severity, .time, .msg] | join(" | ")'
+          /tmp/peribolos --config-path /tmp/peribolos.yaml  --fix-org --fix-org-members --fix-teams --fix-team-members --fix-repos --fix-team-repos --min-admins 2 --github-token-path auth.txt --confirm 2>&1 | jq -r '[.severity, .time, .msg] | join(" | ")'
           kill $pid
           rm auth.txt


### PR DESCRIPTION
The last CI run [skipped configuration the repo](https://github.com/complytime/.github/actions/runs/11832686364/job/32969919911#step:8:73) access for the new teams. This adds `--fix-team-repos`.