### PR TITLE
Update team visibility settings

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -32,6 +32,7 @@ orgs:
     teams:
       complytime-approvers:
         description: This would be a CODEOWNER group for cmd complytime
+        privacy: closed
         members:
         - d10n
         - gvauter
@@ -43,6 +44,7 @@ orgs:
           complytime: write
       openscap-plugin-approvers:
         description: This would be a CODEOWNER group for cmd openscap-plugin
+        privacy: closed
         members:
         - marcusburghardt
         - vojtapolasek
@@ -50,6 +52,7 @@ orgs:
           complytime: write
       complytime-dev:
         description: people working on complytime repo
+        privacy: closed
         members:
         - d10n
         - gvauter


### PR DESCRIPTION
Update the team visibility settings:
`privacy` string
The level of privacy this team should have. The options are:

- secret - only visible to organization owners and members of this team.

- closed - visible to all members of this organization.

- Default: secret
