### PR TITLE
Add write permissions for c2p-fork

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -65,3 +65,4 @@ orgs:
         - vojtapolasek
         repos:
           complytime: write
+          compliance-to-policy-go: write


### PR DESCRIPTION
Needed for collaboration on upstream contributions back to `compliance-to-policy-go`.