### PR TITLE
Add oscal-sdk-go fork to peribolos config

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -73,4 +73,5 @@ orgs:
         repos:
           complytime: write
           compliance-to-policy-go: write
+          oscal-sdk-go: write
           trestle-bot: write


### PR DESCRIPTION
Give `complytime-dev` access to `oscal-sdk-go` fork