### PR TITLE
chore: add complytime-demos repo

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -28,6 +28,10 @@ orgs:
         default_branch: main
         description: ComplyTime project
         has_projects: true
+      "complytime-demos":
+        default_branch: main
+        description: A repository to hold automation and examples used to demo ComplyTime features.
+        has_projects: true
       "trestle-bot":
         default_branch: main
         description: A workflow automation tool for `compliance-trestle`
@@ -62,7 +66,7 @@ orgs:
         repos:
           complytime: write
       complytime-dev:
-        description: people working on complytime repo
+        description: People working on complytime repo
         privacy: closed
         members:
         - d10n
@@ -76,6 +80,7 @@ orgs:
         - vojtapolasek
         repos:
           complytime: write
+          complytime-demos: write
           compliance-to-policy-go: write
           trestle-bot: write
           oscal-content: write


### PR DESCRIPTION
This repository is intended to be used as base for Demos using ComplyTime features.