### PR TITLE
fix: conflict of roles for marcusburghardt

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -16,7 +16,6 @@ orgs:
     members:
       - beatrizmcouto
       - gvauter
-      - marcusburghardt
       - qduanmu
       - RichardXuan
       - vojtapolasek


### PR DESCRIPTION
@marcusburghardt was included in `admin` but not removed from `members`, causing conflict permissions where admin access was not granted.