### PR TITLE
ci: introduce yamllint check

### DIFF
--- a/.github/workflows/validate-peribolos.yml
+++ b/.github/workflows/validate-peribolos.yml
@@ -16,10 +16,15 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: './go.mod'
+
       - name: verify go modules and vendor directory
         run: |
           go mod tidy
           go mod vendor
+
       - name: running unit tests
         run: |
           go test ./...
+
+      - name: Install yamllint and check peribolos.yaml
+        run: pip install yamllint && yamllint peribolos.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+extends: default
+
+# https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  indentation:
+    spaces: consistent
+  line-length: disable

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -62,13 +62,13 @@ orgs:
         description: This would be a CODEOWNER group for cmd complytime
         privacy: closed
         members:
-        - gvauter
-        - hbraswelrh
-        - huiwangredhat
-        - jpower432
-        - marcusburghardt
-        - qduanmu
-        - AlexXuan233
+          - gvauter
+          - hbraswelrh
+          - huiwangredhat
+          - jpower432
+          - marcusburghardt
+          - qduanmu
+          - AlexXuan233
         repos:
           complyctl: write
           vagrant-boxes: write
@@ -76,22 +76,22 @@ orgs:
         description: This would be a CODEOWNER group for cmd openscap-plugin
         privacy: closed
         members:
-        - gvauter
-        - marcusburghardt
+          - gvauter
+          - marcusburghardt
         repos:
           complyctl: write
       complytime-dev:
         description: People working on complytime repo
         privacy: closed
         members:
-        - gvauter
-        - hbraswelrh
-        - huiwangredhat
-        - jpower432
-        - marcusburghardt
-        - qduanmu
-        - AlexXuan233
-        - beatrizmcouto
+          - gvauter
+          - hbraswelrh
+          - huiwangredhat
+          - jpower432
+          - marcusburghardt
+          - qduanmu
+          - AlexXuan233
+          - beatrizmcouto
         repos:
           cac-content: write
           compliance-to-policy-go: write


### PR DESCRIPTION
Besides the nice checks introduced in https://github.com/complytime/.github/pull/36 also includes yamllint to keep the yaml file consistent.

Here is a simple way to test it locally:
```
pip install yamllint
yamllint peribolos.yaml
```