### PR TITLE
ci: update setup-go and pin checkout version

### DIFF
--- a/.github/workflows/apply_peribolos.yml
+++ b/.github/workflows/apply_peribolos.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: "1.23"
           

--- a/.github/workflows/apply_peribolos.yml
+++ b/.github/workflows/apply_peribolos.yml
@@ -15,14 +15,14 @@ jobs:
           go-version: "1.23"
           
       - name: Checkout complytime/.github repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         
       - name: Copy peribolos.yaml
         run: cp peribolos.yaml  /tmp
       
       - name: Checkout ghproxy and peribolos code
         if: ${{ github.repository_owner == 'complytime' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: kubernetes-sigs/prow
 

--- a/.github/workflows/validate-peribolos.yml
+++ b/.github/workflows/validate-peribolos.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: './go.mod'
 


### PR DESCRIPTION
This PR replaces the dependabot PR https://github.com/complytime/.github/pull/42 while also ensuring pinned versions.