### PR TITLE
chore: update member permissions and add complytime-providers repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jflowers @jpower432 @huiwangredhat @marcusburghardt
+* @jflowers @jpower432 @marcusburghardt

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -201,8 +201,8 @@ func TestOrgs(t *testing.T) {
 			t.Errorf("users do not match in CODEOWNERS and org admins '%s': %s", *org.Name, strings.Join(diff.UnsortedList(), ", "))
 		}
 
-		if n := len(approvers); n < 4 {
-			t.Errorf("Require at least 4 approvers, found %d: %s", n, strings.Join(approvers.UnsortedList(), ", "))
+		if n := len(approvers); n < 3 {
+			t.Errorf("Require at least 3 approvers, found %d: %s", n, strings.Join(approvers.UnsortedList(), ", "))
 		}
 
 		if err := testDuplicates(approvers); err != nil {

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -6,7 +6,6 @@ orgs:
     has_repository_projects: true
     members_can_create_repositories: true
     admins:
-      - huiwangredhat
       - jflowers
       - jpower432
       - marcusburghardt
@@ -17,6 +16,7 @@ orgs:
       - bplaxco
       - gvauter
       - hbraswelrh
+      - huiwangredhat
       - qduanmu
       - sonupreetam
       - vojtapolasek
@@ -48,6 +48,10 @@ orgs:
       "complytime-demos":
         default_branch: main
         description: A repository to hold automation and examples used to demo ComplyTime features.
+        has_projects: true
+      "complytime-providers":
+        default_branch: main
+        description: complyctl providers (formerly plugins)
         has_projects: true
       "complytime-policies":
         default_branch: main
@@ -89,6 +93,7 @@ orgs:
           complytime-collector-components: triage
           complytime-demos: triage
           complytime-policies: triage
+          complytime-providers: triage
           gemara-content-service: triage
           org-infra: triage
           website: triage
@@ -96,13 +101,10 @@ orgs:
         description: This would be a CODEOWNERS group for cmd complytime
         privacy: closed
         members:
-          - AlexXuan233
           - gvauter
           - hbraswelrh
-          - huiwangredhat
           - jpower432
           - marcusburghardt
-          - qduanmu
           - sonupreetam
         repos:
           complyctl: write
@@ -118,13 +120,10 @@ orgs:
         description: People working on complytime repo
         privacy: closed
         members:
-          - AlexXuan233
           - gvauter
           - hbraswelrh
-          - huiwangredhat
           - jpower432
           - marcusburghardt
-          - qduanmu
           - sonupreetam
         repos:
           community: write
@@ -134,6 +133,7 @@ orgs:
           complytime-collector-components: write
           complytime-demos: write
           complytime-policies: write
+          complytime-providers: write
           gemara-content-service: write
           org-infra: write
           website: write


### PR DESCRIPTION
## Summary

- Update member roles and team assignments in peribolos.yaml
- Add `complytime-providers` repository to org-level repos, `community-managers` team (triage), and `complytime-dev` team (write)
- Update `complytime-providers` description to `"complyctl providers (formerly plugins)"` reflecting the terminology change

## Related Issues

- N/A

## Review Hints

- The member permission changes (moving `huiwangredhat` from admins to members, removing users from certain teams) were made by the author prior to this PR.
- The `complytime-providers` repo was the only org repository missing from peribolos.yaml (excluding `nunya` and `roadmap` which are intentionally omitted).