### PR TITLE
chore: adds psc org members to peribolos

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -12,9 +12,17 @@ orgs:
       - pme-bot
     members:
       - beatrizmcouto
+      - benroose
       - bplaxco
+      - fortiz-ai
       - gvauter
       - hbraswelrh
+      - jamimoor
+      - JenniferPrivette
+      - mraml
+      - nladha09
+      - phoward-rh
+      - rbaratam-psc
       - sonupreetam
       - trevor-vaughan
       - vojtapolasek


### PR DESCRIPTION
## Description

This PR adds the list of users below to the ComplyTime Organization as `members`. All usernames were taken from GitHub Red Hat Product Security Organization, Slack message, or internal resources with profiles linked. 

1. Alex Langston [mraml](https://github.com/mraml) 
2. Patrick Howard [phoward-rh ](https://github.com/phoward-rh) 
3. Ramki Baratam [rbaratam-psc](https://github.com/rbaratam-psc) 
4. Jennifer Privette [JenniferPrivette](https://github.com/JenniferPrivette) 
5. Ben Roose [benroose](https://github.com/benroose) 
6. Noreen Carmichael [nladha09](https://github.com/nladha09) 
7. Jamila Moore [jamimoor ](https://github.com/jamimoor) 
8. Fabian Ortiz [fortiz-ai](https://github.com/fortiz-ai)

## Review Hints

- [ ] Ensure usernames are consistent with list of names