### PR TITLE
chore: adds psc leadership as members

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -11,9 +11,11 @@ orgs:
       - marcusburghardt
       - pme-bot
     members:
+      - au-der
       - beatrizmcouto
       - benroose
       - bplaxco
+      - eeasley2014
       - fortiz-ai
       - gvauter
       - hbraswelrh


### PR DESCRIPTION
## Description

This PR adds the list of users below to the ComplyTime Organization as `members`. All usernames were taken from GitHub Red Hat Product Security Organization, Slack message, or internal resources with profiles linked. 

1. Tara Houlden [au-der](https://github.com/au-der)
2. Elizabeth Easley [eeasley2014](https://github.com/eeasley2014 )

## Review Hints

- [ ] Ensure usernames are consistent with list of names