### PR TITLE
docs: mark complyscribe as archived in org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,8 +21,7 @@ We believe that effective compliance automation must be built on a foundation th
 ComplyTime is built on a foundation of modern, microservice-based components designed for flexibility and scale.
 
 * **[complyctl](https://github.com/complytime/complyctl)**: A CLI tool providing a consistent compliance foundation for platforms like RHEL.
-* **[complyscribe](https://github.com/complytime/complyscribe)**: A key component of our pluggable framework, this service acts as a compliance-to-policy (C2P) engine, designed to be extensible for various compliance frameworks, not only OSCAL.
- <!-- TODO: A key component of our pluggable framework, this compliance authoring tool operates behind the scenes for an extensible integration for various compliance frameworks, not specific to OSCAL. -->
+* **[complyscribe](https://github.com/complytime/complyscribe)** *(archived)*: Previously used for CaC/OSCAL content transformation.
 * **[complybeacon](https://github.com/complytime/complybeacon)**: A observability toolkit leveraging OpenTelemetry to simplify audit logging and evidence collection in distributed environments like Kubernetes.
 * **[complytime-demos](https://github.com/complytime/complytime-demos)**: A collection of demonstrations and examples for using the ComplyTime framework.
 


### PR DESCRIPTION
## Summary

Updates the organization profile README to reflect that complyscribe is being archived.

### Changes

- **profile/README.md**: Updated complyscribe entry to indicate it is archived and has been superseded by complyctl with Gemara integration. Removed the stale TODO comment.

### Context

ComplyScribe was built to transform compliance content between CaC/content and OSCAL formats, providing OSCAL content consumed by complyctl. However, complyctl has been redesigned to use Gemara as its core engine and no longer requires OSCAL as input, making complyscribe obsolete.