### PR TITLE
fix: resolve runtime failures in peribolos workflows

### DIFF
--- a/.github/workflows/apply_peribolos.yml
+++ b/.github/workflows/apply_peribolos.yml
@@ -90,11 +90,12 @@ jobs:
             --fix-team-repos
             --min-admins 2
             --require-self=false
-            --github-token-path <(printf '%s' "$APP_TOKEN")
           )
 
           if [ "$DRY_RUN" != "true" ]; then
             PERIBOLOS_ARGS+=(--confirm)
           fi
 
-          /tmp/peribolos "${PERIBOLOS_ARGS[@]}" 2>&1 | jq -r '[.severity, .time, .msg] | join(" | ")'
+          /tmp/peribolos "${PERIBOLOS_ARGS[@]}" \
+            --github-token-path <(printf '%s' "$APP_TOKEN") \
+            2>&1 | jq -r '[.severity, .time, .msg] | join(" | ")'

--- a/.github/workflows/drift_detection.yml
+++ b/.github/workflows/drift_detection.yml
@@ -26,7 +26,10 @@ jobs:
         with:
           go-version-file: './go.mod'
 
-      - name: Checkout and build peribolos
+      - name: Copy peribolos.yaml
+        run: cp peribolos.yaml /tmp
+
+      - name: Checkout peribolos code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: kubernetes-sigs/prow
@@ -52,12 +55,12 @@ jobs:
         run: |
           set -o pipefail
           /tmp/peribolos \
-            --config-path peribolos.yaml \
+            --config-path /tmp/peribolos.yaml \
             --require-self=false \
             --github-token-path <(printf '%s' "$APP_TOKEN") \
             --dump complytime \
             --dump-full 2>/tmp/peribolos-dump-stderr.log | yq -P 'sort_keys(..)' > /tmp/org-actual.yaml
-          yq -P 'sort_keys(..)' peribolos.yaml > /tmp/org-expected.yaml
+          yq -P 'sort_keys(..)' /tmp/peribolos.yaml > /tmp/org-expected.yaml
 
       - name: Compare org state
         id: diff


### PR DESCRIPTION
## Summary

Fixes two runtime bugs introduced in PR #89 that cause both the apply and drift detection workflows to fail after merge.

**Bug 1 — Apply workflow: process substitution inside bash array**

`<(printf '%s' "$APP_TOKEN")` was placed inside a bash array assignment. Bash evaluates process substitutions immediately during the assignment, creating a fd like `/dev/fd/63`. However, that fd is only valid within the compound command where it was created. By the time `peribolos` reads `"${PERIBOLOS_ARGS[@]}"` in a later command, the fd is closed.

Symptom: `printf: write error: Broken pipe` then `fatal | Error getting GitHub client.`

Fix: move `--github-token-path <(printf '%s' "$APP_TOKEN")` out of the array into the direct command invocation, where the fd remains valid for the entire pipeline element.

**Bug 2 — Drift detection: missing peribolos.yaml after prow checkout**

The `actions/checkout` for `kubernetes-sigs/prow` overwrites the workspace, replacing `peribolos.yaml` with prow repo contents. The apply workflow already handles this by copying `peribolos.yaml` to `/tmp` before checkout, but the drift detection workflow was missing this step.

Symptom: `Process completed with exit code 1` (peribolos cannot find config file).

Fix: add `cp peribolos.yaml /tmp` step before the prow checkout and reference `/tmp/peribolos.yaml` in all subsequent steps (same pattern as apply workflow).

**Note on ghproxy warning**: The log line `"It doesn't look like you are using ghproxy..."` is a cosmetic warning from Prow, not an error. It fires whenever `--github-token-path` is used without a local ghproxy cache. It cannot be suppressed via CLI flags and does not affect functionality. For a small org (~12 repos, ~20 members), API rate limiting is not a concern. This warning was also present in the original workflow before PR #89.

## Related Issues

- Fixes failing workflow runs after PR #89 merge:
  - https://github.com/complytime/.github/actions/runs/25652721857 (drift detection)
  - https://github.com/complytime/.github/actions/runs/25672252240 (apply)

## Review Hints

- Both bugs were locally verified with a test script that simulates peribolos flag-based argument parsing. The BAD pattern (process substitution in array) fails with "could not read token from /dev/fd/63" while the GOOD pattern (process substitution in direct command) succeeds.

- The diff is minimal: 2 files changed. Focus on `apply_peribolos.yml` lines 99-101 (process substitution moved to command invocation) and `drift_detection.yml` lines 29-30 + 58 + 63 (copy step added, paths updated to `/tmp/`).