### PR TITLE
chore: add anuagarw as organization member

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -10,6 +10,7 @@ orgs:
       - jpower432
       - marcusburghardt
     members:
+      - anuagarw
       - au-der
       - beatrizmcouto
       - benroose


### PR DESCRIPTION
Add **anuagarw** to the complytime organization members list in `peribolos.yaml`.