### PR TITLE
fix: add --ignore-secret-teams to peribolos workflows

### DIFF
--- a/.github/workflows/peribolos-apply.yml
+++ b/.github/workflows/peribolos-apply.yml
@@ -103,6 +103,7 @@ jobs:
             --required-admins marcusburghardt
             --require-self=false
             --ignore-enterprise-teams
+            --ignore-secret-teams
           )
 
           if [ "$DRY_RUN" != "true" ]; then

--- a/.github/workflows/peribolos-drift.yml
+++ b/.github/workflows/peribolos-drift.yml
@@ -81,6 +81,7 @@ jobs:
             --required-admins marcusburghardt \
             --require-self=false \
             --ignore-enterprise-teams \
+            --ignore-secret-teams \
             --github-token-path "$TOKEN_FILE" \
             > /tmp/peribolos-dryrun.log 2>&1 || true
 


### PR DESCRIPTION
## Summary

Peribolos with `--fix-team-repos` reconciles each team's repo permissions to match exactly what's declared in `peribolos.yaml`. Private repos deliberately excluded from the public config had their manually-set team permissions stripped on every scheduled or push-triggered apply run.

The `--fix-team-repos` flag computes `unused = have - want` for each team's repo list and removes all repos not in the YAML. Since private repos are intentionally omitted from `peribolos.yaml`, any team access manually granted to those repos was removed by the next peribolos run.

This PR adds `--ignore-secret-teams` to both peribolos workflows (`peribolos-apply.yml` and `peribolos-drift.yml`), causing peribolos to completely skip secret-privacy teams (creation, deletion, membership, and repo mappings). This allows manually-managed secret teams to grant access to private repos without interference.

Note: no secret teams currently exist in the managed config, so this change has no side effects on existing team management. Long-term, an `--exclude-repos` flag contributed upstream to `kubernetes-sigs/prow` would provide more granular control.

## Related Issues

- None

## Review Hints

- Both workflow files receive the same one-line addition of `--ignore-secret-teams` right after the existing `--ignore-enterprise-teams` flag.
- The flag is documented in the peribolos source at `kubernetes-sigs/prow/cmd/peribolos/main.go` — it causes secret-privacy teams to be excluded from the `slugs` set entirely, making them invisible to the delete and reconciliation logic.
- To verify: after merging, trigger a manual `workflow_dispatch` of `peribolos-apply.yml` with `dry-run: true` and confirm secret teams are not listed in the output.