### PR TITLE
chore: upgrade community-managers team from triage to write

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -97,7 +97,7 @@ orgs:
         members:
           - bplaxco
       community-managers:
-        description: Community managers who handle labels, reviews, and issue triage without write access
+        description: Community managers who handle labels, reviews, issue triage, and project coordination
         privacy: closed
         members:
           - beatrizmcouto
@@ -105,18 +105,18 @@ orgs:
           - sonupreetam
         repos:
           ".github": triage
-          community: triage
-          complyctl: triage
-          complypack: triage
-          complyscribe: triage
-          complytime: triage
-          complytime-collector-components: triage
-          complytime-demos: triage
-          complytime-policies: triage
-          complytime-providers: triage
-          gemara-content-service: triage
-          org-infra: triage
-          website: triage
+          community: write
+          complyctl: write
+          complypack: write
+          complyscribe: write
+          complytime: write
+          complytime-collector-components: write
+          complytime-demos: write
+          complytime-policies: write
+          complytime-providers: write
+          gemara-content-service: write
+          org-infra: write
+          website: write
       complytime-approvers:
         description: Write access to non-code repos for project stakeholders
         privacy: closed


### PR DESCRIPTION
## Summary

Upgrade the `community-managers` team repo permissions from `triage` to `write` on all repositories except `.github`, which remains at `triage` to preserve the existing restriction on the org management repo.

## Motivation

The program manager (`beatrizmcouto`) in the `community-managers` team needs to perform project coordination tasks that the `triage` role does not allow:

| Action | Required permission |
|--------|-------------------|
| Create, edit, and delete label definitions | `write` |
| Transfer issues between repositories | `write` on destination |
| Edit other people's comments (moderation) | `write` |
| Assign reviewers | `triage` (already had) |

## What changes

- **Team description** updated to reflect the new scope (removed "without write access").
- **12 repo entries** changed from `triage` to `write` in the `community-managers` team.
- **`.github` stays at `triage`** -- no non-admin write access to the org management repo.

## Effective impact

This change only elevates permissions for `beatrizmcouto`. The other two `community-managers` members (`hbraswelrh`, `sonupreetam`) already have `write` access through the `complytime-dev` team.

## Guardrails

- Branch protection rules on `main` require PRs and reviews.
- CODEOWNERS gates require approvals from the correct developer teams.
- `write` role **cannot** change branch protection rules or repository settings (those require `maintain` or `admin`).
- The `.github` org management repo remains restricted.