### PR TITLE
fix: address safe-settings review feedback and fix workflow runtime failure

### DIFF
--- a/.github/workflows/safe_settings_sync.yml
+++ b/.github/workflows/safe_settings_sync.yml
@@ -32,9 +32,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Pin to a specific release tag. Update via a deliberate PR.
-  # TODO: Replace with a commit SHA after initial validation.
-  SAFE_SETTINGS_VERSION: "2.1.17"
+  # Pin to a specific commit SHA. Update via a deliberate PR.
+  SAFE_SETTINGS_VERSION: "3d61f1f44c78ce40ec1e58120250193ebae7787b"  # 2.1.21
   SAFE_SETTINGS_CODE_DIR: ".safe-settings-code"
 
 jobs:
@@ -107,7 +106,7 @@ jobs:
           path: ${{ env.SAFE_SETTINGS_CODE_DIR }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642195f572a2b2b9a5e172c  # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '20'
 

--- a/config/boundary_test.go
+++ b/config/boundary_test.go
@@ -35,7 +35,8 @@ var peribolosOwnedFields = []string{
 // Peribolos config must NOT set these fields.
 var safeSettingsOwnedFields = []string{
 	"has_wiki",
-	"has_issues",
+	"has_issues", // reserved; not actively managed in initial deployment
+
 	"allow_auto_merge",
 	"delete_branch_on_merge",
 	"allow_squash_merge",

--- a/openspec/changes/adopt-safe-settings/specs/org-rulesets-as-code/spec.md
+++ b/openspec/changes/adopt-safe-settings/specs/org-rulesets-as-code/spec.md
@@ -18,19 +18,20 @@ default branch of all code repositories. The ruleset SHALL enforce:
 The ruleset SHALL target `~DEFAULT_BRANCH` and SHALL include code repos via
 `repository_name` conditions.
 
-Bypass actors SHALL be limited to `OrganizationAdmin` with `bypass_mode: always`.
+The ruleset SHALL NOT define bypass actors. All users, including org
+admins, follow the same rules.
 
 #### Scenario: Code repo default branch protected
 
 - **GIVEN** the org-level ruleset is defined in safe-settings config
 - **WHEN** safe-settings applies the ruleset
-- **THEN** all code repos have the default branch protected with signed
-  commits, required reviews, and no force pushes
+- **THEN** all code repos have the default branch protected with
+  required reviews and no force pushes
 
-#### Scenario: Non-admin cannot bypass rules
+#### Scenario: Admin cannot bypass rules
 
-- **GIVEN** the ruleset bypass_actors only includes OrganizationAdmin
-- **WHEN** a non-admin user attempts to force push to the default branch
+- **GIVEN** the ruleset has no bypass actors
+- **WHEN** an org admin attempts to force push to the default branch
 - **THEN** the push is rejected
 
 ### Requirement: Lighter ruleset for non-code repos

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -72,13 +72,6 @@ rulesets:
     target: branch
     enforcement: active
 
-    bypass_actors:
-      # actor_id 1 is the GitHub-reserved ID for OrganizationAdmin.
-      # See: https://docs.github.com/en/rest/orgs/rules
-      - actor_id: 1
-        actor_type: OrganizationAdmin
-        bypass_mode: always
-
     conditions:
       ref_name:
         include:
@@ -135,13 +128,6 @@ rulesets:
   - name: "safe-settings: non-code repos"
     target: branch
     enforcement: active
-
-    bypass_actors:
-      # actor_id 1 is the GitHub-reserved ID for OrganizationAdmin.
-      # See: https://docs.github.com/en/rest/orgs/rules
-      - actor_id: 1
-        actor_type: OrganizationAdmin
-        bypass_mode: always
 
     conditions:
       ref_name:


### PR DESCRIPTION
## Summary

Address PR #114 review feedback and fix the workflow runtime failure caused by an invalid `actions/setup-node` SHA.

## Related Issues

- Closes #136 — Pin safe-settings version to commit SHA instead of mutable tag
- Closes #137 — Clarify has_issues as reserved-but-unmanaged in boundary tests
- Closes #138 — Remove OrganizationAdmin bypass actors from safe-settings rulesets

## Review Hints

- Review commits individually, each addresses a separate issue:
  1. `fix(ci):` Fix broken setup-node SHA, upgrade both setup-node (v4.4.0 → v6.4.0) and safe-settings (2.1.17 → 2.1.21), pin to verified commit SHAs
  2. `chore:` Add clarifying comment for `has_issues` in boundary_test.go
  3. `fix:` Remove `bypass_actors` from both rulesets in settings.yml and update the spec

- The first commit is the critical fix — the workflow currently fails on every run due to the invalid SHA.

- Full local validation: `make sanity && make test-unit`
