### PR TITLE
fix: address safe-settings runtime issues from initial testing

### DIFF
--- a/.github/workflows/safe_settings_sync.yml
+++ b/.github/workflows/safe_settings_sync.yml
@@ -23,6 +23,14 @@ name: Safe Settings Sync
         required: false
         type: string
         default: ''
+      version:
+        description: >-
+          safe-settings commit SHA or tag to use.
+          Default is 2.1.18 (last version compatible with Probot v13).
+          See upstream issue github/safe-settings#955 for Probot v14 status.
+        required: false
+        type: string
+        default: '594f3c706de6c4ddafb1a86dfa7468f19337e54f'
 
 permissions:
   contents: none
@@ -32,8 +40,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Pin to a specific commit SHA. Update via a deliberate PR.
-  SAFE_SETTINGS_VERSION: "3d61f1f44c78ce40ec1e58120250193ebae7787b"  # 2.1.21
   SAFE_SETTINGS_CODE_DIR: ".safe-settings-code"
 
 jobs:
@@ -102,7 +108,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: github/safe-settings
-          ref: ${{ env.SAFE_SETTINGS_VERSION }}
+          ref: ${{ inputs.version }}
           path: ${{ env.SAFE_SETTINGS_CODE_DIR }}
 
       - name: Setup Node.js

--- a/safe-settings/deployment-settings.yml
+++ b/safe-settings/deployment-settings.yml
@@ -4,15 +4,26 @@
 # This file is read at runtime via the DEPLOYMENT_CONFIG_FILE env var.
 # See: https://github.com/github/safe-settings
 
-# Repositories excluded from safe-settings management.
-# The .github repo is excluded to avoid circular dependency (it hosts
-# the safe-settings config). Its ruleset is managed manually via the
-# GitHub UI.
+# Repositories managed by safe-settings (allowlist approach).
+# Only repos listed here are managed. All others are ignored,
+# including the .github admin repo (avoids circular dependency)
+# and any repos not onboarded to safe-settings.
+#
+# IMPORTANT: safe-settings uses regex matching for restrictedRepos.
+# Entries must be anchored with ^ and $ for exact matching, otherwise
+# "complytime" would also match "complytime-demos", etc.
 restrictedRepos:
-  exclude:
-    - .github
-    - admin
-    - safe-settings
+  include:
+    - "^complyctl$"
+    - "^community$"
+    - "^complypack$"
+    - "^complytime$"
+    - "^complytime-collector-components$"
+    - "^complytime-demos$"
+    - "^complytime-policies$"
+    - "^complytime-providers$"
+    - "^org-infra$"
+    - "^website$"
 
 # Config validators run against each config entry before applying.
 # Return true to allow, false to reject.

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -115,7 +115,11 @@ rulesets:
       # Preserve any status checks configured outside of safe-settings
       # (e.g., via individual repo workflow configurations).
       # Each repo has different CI checks (unit-test, test, test(3.10),
-      # etc.) — EXTERNALLY_DEFINED keeps existing checks untouched.
+      # etc.) — EXTERNALLY_DEFINED retains existing checks on update.
+      # On initial ruleset creation this rule is dropped (by design)
+      # since there are no existing checks to retain. Once the ruleset
+      # exists and checks are added externally, subsequent syncs
+      # preserve them.
       - type: required_status_checks
         parameters:
           strict_required_status_checks_policy: true
@@ -153,7 +157,12 @@ rulesets:
       # 1 approver, no dismiss stale reviews, no code owner review,
       # no last push approval. Matches the current complytime-demos
       # and community baseline.
+      # All parameters must be specified — the GitHub API rejects
+      # partial pull_request parameter sets with HTTP 422.
       - type: pull_request
         parameters:
           required_approving_review_count: 1
+          dismiss_stale_reviews_on_push: false
+          require_code_owner_review: false
+          require_last_push_approval: false
           required_review_thread_resolution: false

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -80,6 +80,7 @@ rulesets:
       repository_name:
         include:
           - complyctl
+          - complypack
           - complytime-collector-components
           - complytime-policies
           - complytime-providers

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -88,12 +88,14 @@ rulesets:
         exclude: []
 
     rules:
+      # Restrict creation of refs matching the default branch pattern.
+      # Prevents recreating the default branch if deleted.
+      - type: creation
+
       # Prevent deletion of the default branch.
-      # Currently enforced on all repos that have rulesets.
       - type: deletion
 
       # Prevent force pushes to the default branch.
-      # Currently enforced on all repos that have rulesets.
       - type: non_fast_forward
 
       # Pull request requirements.
@@ -148,6 +150,9 @@ rulesets:
         exclude: []
 
     rules:
+      # Restrict creation of refs matching the default branch pattern.
+      - type: creation
+
       # Prevent deletion of the default branch.
       - type: deletion
 

--- a/safe-settings/suborgs/code-repos.yml
+++ b/safe-settings/suborgs/code-repos.yml
@@ -11,6 +11,7 @@
 
 suborgrepos:
   - complyctl
+  - complypack
   - complytime-collector-components
   - complytime-policies
   - complytime-providers


### PR DESCRIPTION
## Summary

Fix three runtime issues discovered during initial safe-settings testing against `complytime-demos`.

## Related Issues

- Upstream: github/safe-settings#955 (Probot v14 breaking change in full-sync.js)

## Review Hints

- Review commits individually, each addresses a separate issue:
  1. `fix(ci):` Downgrade safe-settings to 2.1.18 (last Probot v13 version). Adds a `version` input to `workflow_dispatch` so newer versions can be tested without code changes.
  2. `fix:` Add missing `pull_request` parameters to the non-code repos ruleset. The GitHub API rejects partial parameter sets with HTTP 422.
  3. `fix:` Switch `restrictedRepos` from exclude to include (allowlist). Anchor all entries with `^...$` since safe-settings uses regex matching. Add `complypack` to code repos suborg and ruleset.

- The `version` input defaults to the 2.1.18 commit SHA (`594f3c706de6c4ddafb1a86dfa7468f19337e54f`). To test a newer safe-settings version, enter a different SHA or tag in the workflow dispatch UI.

- After merge, test with: Actions > "Safe Settings Sync" > Run workflow > `dry-run=true`, `repos=complytime-demos`

- Full local validation: `make sanity`
