### PR TITLE
chore: remove gemara-content-service references

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -298,7 +298,7 @@ The following repos are excluded from safe-settings management:
 - `.github` — the admin repo (avoids circular dependency). Its
   ruleset ("verify") is managed manually via the GitHub UI.
 - `complyscribe` — archived.
-- `gemara-content-service` — pending archival.
+- `gemara-content-service` — archived (moved to complytime-labs).
 
 These are listed in `safe-settings/deployment-settings.yml` under
 `restrictedRepos` and/or excluded from suborg files.

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -75,10 +75,6 @@ orgs:
         default_branch: main
         description: Repository for complytime engineering policies expressed in Gemara
         has_projects: true
-      "gemara-content-service":
-        default_branch: main
-        description: A content delivery and enrichment service for Gemara compliance artifacts.
-        has_projects: true
       "org-infra":
         default_branch: main
         description: Repository for reusable workflows, shared configurations, and templates used in ComplyTime org.
@@ -115,7 +111,6 @@ orgs:
           complytime-demos: write
           complytime-policies: write
           complytime-providers: write
-          gemara-content-service: write
           org-infra: write
           website: write
       complytime-approvers:
@@ -217,6 +212,5 @@ orgs:
           complytime-demos: write
           complytime-policies: write
           complytime-providers: write
-          gemara-content-service: write
           org-infra: write
           website: write

--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -25,7 +25,7 @@
 #
 # Excluded from safe-settings management:
 #   complyscribe:              archived
-#   gemara-content-service:    scheduled for archival
+#   gemara-content-service:    archived (moved to complytime-labs)
 
 repository:
   # Allow auto-merge on pull requests when all requirements are met.

--- a/safe-settings/suborgs/code-repos.yml
+++ b/safe-settings/suborgs/code-repos.yml
@@ -7,7 +7,7 @@
 # Only override settings here if code repos need different values
 # than the org-wide defaults.
 #
-# Excluded: complyscribe (archived), gemara-content-service (archival pending)
+# Excluded: complyscribe (archived), gemara-content-service (archived)
 
 suborgrepos:
   - complyctl


### PR DESCRIPTION
The gemara-content-service repository has been moved to complytime-labs and archived.

### Changes
- **peribolos.yaml**: Remove repo definition and team write permissions (`community-managers`, `complytime-dev`)
- **MAINTAINING.md**: Update excluded repos section from "pending archival" to "archived (moved to complytime-labs)"
- **safe-settings/settings.yml**: Update comment from "scheduled for archival" to "archived (moved to complytime-labs)"
- **safe-settings/suborgs/code-repos.yml**: Update comment from "archival pending" to "archived"

> Ready for review. Waiting for confirmation on complytime/complytime-collector-components#325 before merging.