### PR TITLE
fix: set GH_REPO for gh CLI in peribolos-drift workflow

### DIFF
--- a/.github/workflows/peribolos-drift.yml
+++ b/.github/workflows/peribolos-drift.yml
@@ -121,6 +121,7 @@ jobs:
         id: existing-issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           ISSUE_NUMBER=$(gh issue list \
             --label peribolos-drift \
@@ -134,6 +135,7 @@ jobs:
         if: steps.drift.outputs.drift == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ steps.existing-issue.outputs.issue_number }}
           WORKFLOW_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |


### PR DESCRIPTION
## Problem

The **Peribolos: Drift** workflow has failed on every single run (all 7 weekly executions) at the "Create or update drift issue" step with exit code 1.

**Root cause:** The workflow has two `actions/checkout` steps. The second one checks out `kubernetes-sigs/prow` **into the default working directory**, overwriting the `.git/config`. When the later steps run `gh issue list` and `gh issue create`, the `gh` CLI resolves the repository from the local git config -- which now points to `kubernetes-sigs/prow` instead of `complytime/.github`.

This causes `gh issue create --label peribolos-drift` to target the wrong repository, where:
- The `GITHUB_TOKEN` has no write access (it's scoped to `complytime/.github`)
- The `peribolos-drift` label does not exist

The label **does exist** on `complytime/.github`, confirming the issue is purely about repository resolution.

## Fix

Set `GH_REPO: ${{ github.repository }}` in the `env` block of both `gh`-using steps ("Check for existing drift issue" and "Create or update drift issue"). This tells the CLI to always target the correct repository regardless of the local checkout state.

## Verification

- Confirmed the `peribolos-drift` label exists on `complytime/.github`
- Confirmed the second `actions/checkout` (for `kubernetes-sigs/prow`) does **not** use the `path:` parameter, so it overwrites the working directory
- All 7 historical runs show the same failure pattern, consistent with a structural (not transient) issue