### PR TITLE
Add homebew-tap repository configuration

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -54,7 +54,7 @@ orgs:
       "complypack":
         default_branch: main
         description: Assessment logic packaging for complyctl
-        has_projects: true 
+        has_projects: true
       "complyscribe":
         default_branch: main
         description: A workflow automation tool for compliance content authoring

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -51,6 +51,10 @@ orgs:
         default_branch: main
         description: A command-line tool for streamlining end-to-end compliance workflows on local systems.
         has_projects: true
+      "complypack":
+        default_branch: main
+        description: Assessment logic packaging for complyctl
+        has_projects: true 
       "complyscribe":
         default_branch: main
         description: A workflow automation tool for compliance content authoring
@@ -75,6 +79,10 @@ orgs:
         default_branch: main
         description: Repository for complytime engineering policies expressed in Gemara
         has_projects: true
+      "homebrew-tap"
+        default_branch: main
+        description: 
+        has_projects: true
       "org-infra":
         default_branch: main
         description: Repository for reusable workflows, shared configurations, and templates used in ComplyTime org.
@@ -82,10 +90,6 @@ orgs:
       "website":
         default_branch: main
         description: The ComplyTime website
-        has_projects: true
-      "complypack":
-        default_branch: main
-        description: Assessment logic packaging for complyctl
         has_projects: true
     teams:
       security-managers:

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -79,9 +79,8 @@ orgs:
         default_branch: main
         description: Repository for complytime engineering policies expressed in Gemara
         has_projects: true
-      "homebrew-tap"
+      "homebrew-tap":
         default_branch: main
-        description: 
         has_projects: true
       "org-infra":
         default_branch: main

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -114,6 +114,7 @@ orgs:
           complytime-demos: write
           complytime-policies: write
           complytime-providers: write
+          homebrew-tap: triage
           org-infra: write
           website: write
       complytime-approvers:
@@ -215,5 +216,6 @@ orgs:
           complytime-demos: write
           complytime-policies: write
           complytime-providers: write
+          homebrew-tap: write
           org-infra: write
           website: write


### PR DESCRIPTION
## Summary

Add a `homebrew-tap` repository and moves `complypack` to proper place in order

## Related Issues

Supports https://github.com/complytime/complyctl/issues/713

## Review Hints

N/A
