### PR TITLE
chore: bump Go version from 1.26.0 to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/complytime/.github
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Summary

Bump the Go toolchain from `1.26.0` to `1.26.5` (latest stable patch release).

## Motivation

Addresses [code scanning alert #27](https://github.com/complytime/.github/security/code-scanning/27), specifically:

- **GO-2026-4918 / CVE-2026-33814**: HTTP/2 SETTINGS infinite loop DoS in `net/http` (fixed in Go >= 1.26.3)

The `golang.org/x/net` and `golang.org/x/sys` dependency vulnerabilities from the same alert were already addressed in prior dependency updates.

## Changes

- `go.mod`: `go 1.26.0` -> `go 1.26.5`

No dependency changes — `go mod tidy` and `go mod vendor` produced no diff beyond the version bump.

## Verification

- `go build ./...` — passed
- `go vet ./...` — passed
- `go test ./...` — passed