### PR TITLE
chore: add architectural advisory council

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -132,6 +132,14 @@ orgs:
           community: write
           complytime-demos: write
           website: write
+      architectural-review-board:
+        description: Architectural review board
+        members:
+          - gxmiranda
+          - jpower432
+          - marcusburghardt
+        repos:
+          complytime: maintain
       ampel-provider-approvers:
         description: CODEOWNERS group for ampel-provider in complytime-providers
         privacy: closed
@@ -197,7 +205,6 @@ orgs:
         description: People working on complytime repo
         privacy: closed
         maintainers:
-          - jpower432
           - marcusburghardt
         members:
           - em-redhat

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -134,6 +134,7 @@ orgs:
           website: write
       architectural-review-board:
         description: Architectural review board
+        privacy: closed
         maintainers:
           - jpower432
           - marcusburghardt

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -134,10 +134,11 @@ orgs:
           website: write
       architectural-review-board:
         description: Architectural review board
-        members:
-          - gxmiranda
+        maintainers:
           - jpower432
           - marcusburghardt
+        members:
+          - gxmiranda
         repos:
           complytime: maintain
       ampel-provider-approvers:

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -132,8 +132,8 @@ orgs:
           community: write
           complytime-demos: write
           website: write
-      architectural-review-board:
-        description: Architectural review board
+      architecture-advisory-council:
+        description: Architecture advisory council
         privacy: closed
         maintainers:
           - jpower432


### PR DESCRIPTION
## Summary

- Adds architectural review board team
- Removes `jpower432` from `complytime-dev`

TODO: Update governance under `community` to explain this group. Similar to SIG Architecture not general ComplyTime project oversight.

## Related Issues

N/A

## Review Hints

N/A
