### PR TITLE
feat: promote gxmiranda to org admin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @jflowers @jpower432 @marcusburghardt
-safe-settings/ @jflowers @jpower432 @marcusburghardt
+* @gxmiranda @jflowers @jpower432 @marcusburghardt
+safe-settings/ @gxmiranda @jflowers @jpower432 @marcusburghardt

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -6,6 +6,7 @@ orgs:
     has_repository_projects: true
     members_can_create_repositories: true
     admins:
+      - gxmiranda
       - jflowers
       - jpower432
       - marcusburghardt
@@ -20,7 +21,6 @@ orgs:
       - em-redhat
       - fkolacek-rh
       - fortiz-ai
-      - gxmiranda
       - hbraswelrh
       - jamimoor
       - JenniferPrivette
@@ -140,21 +140,20 @@ orgs:
         description: Architecture advisory council
         privacy: closed
         maintainers:
+          - gxmiranda
           - jpower432
           - marcusburghardt
-        members:
-          - gxmiranda
         repos:
           complytime: maintain
       ampel-provider-approvers:
         description: CODEOWNERS group for ampel-provider in complytime-providers
         privacy: closed
         maintainers:
+          - gxmiranda
           - jpower432
           - marcusburghardt
         members:
           - em-redhat
-          - gxmiranda
           - hbraswelrh
           - sedonnel
           - sonupreetam
@@ -166,11 +165,11 @@ orgs:
         description: CODEOWNERS group for openscap-provider in complytime-providers
         privacy: closed
         maintainers:
+          - gxmiranda
           - jpower432
           - marcusburghardt
         members:
           - em-redhat
-          - gxmiranda
           - hbraswelrh
           - sedonnel
           - sonupreetam
@@ -182,12 +181,12 @@ orgs:
         description: CODEOWNERS group for opa-provider in complytime-providers
         privacy: closed
         maintainers:
+          - gxmiranda
           - jpower432
           - marcusburghardt
         members:
           - em-redhat
           - fortiz-ai
-          - gxmiranda
           - hbraswelrh
           - sedonnel
           - sonupreetam
@@ -211,10 +210,10 @@ orgs:
         description: People working on complytime repo
         privacy: closed
         maintainers:
+          - gxmiranda
           - marcusburghardt
         members:
           - em-redhat
-          - gxmiranda
           - hbraswelrh
           - sedonnel
           - sonupreetam


### PR DESCRIPTION
## Summary

Promote `gxmiranda` from org member to org admin, granting full access to approve and merge PRs in the `.github` repo and across the org.

## Changes

### `peribolos.yaml`
- Move `gxmiranda` from `members` to `admins`
- Move `gxmiranda` from `members` to `maintainers` in all teams where he was listed (required by peribolos for org admins):
  - `architecture-advisory-council`
  - `ampel-provider-approvers`
  - `openscap-provider-approvers`
  - `opa-provider-approvers`
  - `complytime-dev`
- Remove the `complytime-access-managers` team (no longer needed)

### `.github/CODEOWNERS`
- Add `@gxmiranda` to the `*` and `safe-settings/` patterns alongside existing org admins