### PR TITLE
feat: add sedonnel as org member and team member

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -34,6 +34,7 @@ orgs:
       - rbaratam-psc
       - rhaml-23
       - rmonk-redhat
+      - sedonnel
       - sonupreetam
       - trevor-vaughan
       - vojtapolasek
@@ -155,6 +156,7 @@ orgs:
           - em-redhat
           - gxmiranda
           - hbraswelrh
+          - sedonnel
           - sonupreetam
           - trevor-vaughan
           - yvonnedevlinrh
@@ -170,6 +172,7 @@ orgs:
           - em-redhat
           - gxmiranda
           - hbraswelrh
+          - sedonnel
           - sonupreetam
           - trevor-vaughan
           - yvonnedevlinrh
@@ -186,6 +189,7 @@ orgs:
           - fortiz-ai
           - gxmiranda
           - hbraswelrh
+          - sedonnel
           - sonupreetam
           - trevor-vaughan
           - yvonnedevlinrh
@@ -212,6 +216,7 @@ orgs:
           - em-redhat
           - gxmiranda
           - hbraswelrh
+          - sedonnel
           - sonupreetam
           - trevor-vaughan
           - yvonnedevlinrh


### PR DESCRIPTION
## Summary

Add **sedonnel** to the organization with the same access as **em-redhat** and **yvonnedevlinrh**.

### Changes

- Added `sedonnel` to org **members** list
- Added `sedonnel` to **ampel-provider-approvers** team
- Added `sedonnel` to **openscap-provider-approvers** team
- Added `sedonnel` to **opa-provider-approvers** team
- Added `sedonnel` to **complytime-dev** team