### PR TITLE
fix: harden workflow error matching and input validation

### DIFF
--- a/.github/workflows/peribolos-drift.yml
+++ b/.github/workflows/peribolos-drift.yml
@@ -106,6 +106,18 @@ jobs:
           # Filter expected enterprise-member drift
           FILTERED_COUNT=0
           if [ -n "$ENTERPRISE_MEMBERS_IGNORE" ]; then
+            # Validate usernames before building grep pattern.
+            # GitHub usernames allow only [a-zA-Z0-9-], so the values
+            # are safe for grep -vE without regex escaping. This guard
+            # fails fast if an invalid value is ever added.
+            for user in $(echo "$ENTERPRISE_MEMBERS_IGNORE" | tr ',' '\n'); do
+              user=$(echo "$user" | xargs)
+              [ -z "$user" ] && continue
+              if ! [[ "$user" =~ ^[a-zA-Z0-9-]+$ ]]; then
+                echo "::error::Invalid username in ENTERPRISE_MEMBERS_IGNORE: '$user'"
+                exit 1
+              fi
+            done
             IGNORE_PATTERN=$(echo "$ENTERPRISE_MEMBERS_IGNORE" | tr ', ' '\n' \
               | sed '/^$/d' | paste -sd'|' -)
             BEFORE=$(wc -l < /tmp/drift-mutations.txt)

--- a/.github/workflows/safe_settings_sync.yml
+++ b/.github/workflows/safe_settings_sync.yml
@@ -166,7 +166,7 @@ jobs:
               // exist outside the webhook flow. The sync completes
               // and results are logged; only the Check Run reporting
               // fails. Safe to skip.
-              if (String(error).includes('check_suite')) {
+              if (String(error).includes("Cannot read properties of undefined (reading 'check_suite')")) {
                 probot.log.info(
                   'check_suite reporting skipped (expected in full-sync mode). ' +
                   'See: github-community-projects/safe-settings#818'


### PR DESCRIPTION
## Summary

Two small hardening improvements addressing review feedback from @gxmiranda.

### 1. Tighten `check_suite` error matching (safe-settings sync)

**Source**: [PR #186 review](https://github.com/complytime/.github/pull/186#discussion_r3675385855)

Narrows the error guard from a broad `check_suite` substring match to the
exact upstream error message:
```
Cannot read properties of undefined (reading 'check_suite')
```

This prevents accidentally swallowing an unrelated error whose message
happens to contain that substring.

### 2. Validate `ENTERPRISE_MEMBERS_IGNORE` usernames (peribolos drift)

**Source**: [PR #182 review](https://github.com/complytime/.github/pull/182#discussion_r3675358210)

Adds input validation for `ENTERPRISE_MEMBERS_IGNORE` values before they
are used to build a `grep -vE` pattern. GitHub usernames only allow
`[a-zA-Z0-9-]`, so the values are currently safe for regex without
escaping. This guard fails fast if an invalid value is ever added,
preventing unexpected regex behavior.
