### PR TITLE
feat(safe-settings): require code owner review for non-code repos

### DIFF
--- a/safe-settings/settings.yml
+++ b/safe-settings/settings.yml
@@ -20,7 +20,6 @@
 #   complytime-providers:            branch-protection (active)
 #   org-infra:                       Branch Protection (active)
 #   community:                       Branch Protection (active)
-#   complytime-demos:                Branch Protection (active)
 #   website:                         general-rules (active)
 #
 # Excluded from safe-settings management:
@@ -160,15 +159,14 @@ rulesets:
       - type: non_fast_forward
 
       # Pull request requirements — lighter than code repos.
-      # 1 approver, no dismiss stale reviews, no code owner review,
-      # no last push approval. Matches the current complytime-demos
-      # and community baseline.
+      # 1 approver, code owner review required, no dismiss stale
+      # reviews, no last push approval.
       # All parameters must be specified — the GitHub API rejects
       # partial pull_request parameter sets with HTTP 422.
       - type: pull_request
         parameters:
           required_approving_review_count: 1
           dismiss_stale_reviews_on_push: false
-          require_code_owner_review: false
+          require_code_owner_review: true
           require_last_push_approval: false
           required_review_thread_resolution: false


### PR DESCRIPTION
## Summary

Enable `require_code_owner_review` on the **non-code repos** ruleset (`community`, `complytime`, `complytime-demos`, `website`) to enforce CODEOWNERS approval on all managed repositories. The code repos ruleset already has this enabled.

Also removes `complytime-demos` from the migration cleanup list since its legacy repo-level ruleset has been deleted.

## Changes

- `safe-settings/settings.yml`:
  - `require_code_owner_review: false` → `true` in the "safe-settings: non-code repos" ruleset
  - Removed `complytime-demos` from the migration cleanup comment block

## Notes

- All managed repos already have CODEOWNERS files in place (9 in `.github/CODEOWNERS`, `org-infra` at root).
- The `community` repository still has its legacy repo-level ruleset ("Branch Protection") active. It should be kept until this PR is merged and the org-level ruleset is synced with the updated configuration.
- After merging, run the safe-settings sync workflow targeting the non-code repos to apply the change.