### PR TITLE
Add ggbecker as a member and part of the policies approvers.

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -20,6 +20,7 @@ orgs:
       - eeasley2014
       - em-redhat
       - fortiz-ai
+      - ggbecker
       - hbraswelrh
       - jamimoor
       - JenniferPrivette
@@ -198,6 +199,7 @@ orgs:
           - marcusburghardt
         members:
           - fortiz-ai
+          - ggbecker
           - rhaml-23
         repos:
           complytime-policies: write


### PR DESCRIPTION
## Summary
Add ggbecker as a member and part of the `complytime-policies` approvers.
