### PR TITLE
Add SecKatie, iswiac, and ccronca to org members

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -16,11 +16,13 @@ orgs:
       - beatrizmcouto
       - benroose
       - bplaxco
+      - ccronca
       - dbaker-arch
       - eeasley2014
       - em-redhat
       - fortiz-ai
       - hbraswelrh
+      - iswiac
       - jamimoor
       - JenniferPrivette
       - mblanco474
@@ -29,6 +31,7 @@ orgs:
       - Pranshul01051987
       - rbaratam-psc
       - rhaml-23
+      - SecKatie
       - sedonnel
       - sonupreetam
       - trevor-vaughan


### PR DESCRIPTION
Add the following users as organization members in peribolos.yaml:

- SecKatie
- iswiac
- ccronca

These users are added to the `members` list in alphabetical order.