### PR TITLE
chore: adds cdaniels255 as org member

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -17,6 +17,7 @@ orgs:
       - benroose
       - bplaxco
       - ccronca
+      - cdaniels255
       - dbaker-arch
       - eeasley2014
       - em-redhat
@@ -211,6 +212,7 @@ orgs:
           - gxmiranda
           - marcusburghardt
         members:
+          - cdaniels255
           - em-redhat
           - hbraswelrh
           - sedonnel


### PR DESCRIPTION
## Summary

This PR adds Chris Daniels (`@cdaniels255`) as a member to to the ComplyTime GitHub org. 

## Related Issues

- N/A

## Review Hints

- Validate user `@cdaniels255` 
- Alphabetical order