### PR TITLE
Add dmairrh as org member

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -17,6 +17,7 @@ orgs:
       - benroose
       - bplaxco
       - dbaker-arch
+      - dmairrh
       - eeasley2014
       - em-redhat
       - fortiz-ai


### PR DESCRIPTION
Add dmairrh to the complytime organization members list in peribolos.yaml.